### PR TITLE
Ditching replace and using trasclude

### DIFF
--- a/angular-bootstrap-checkbox.js
+++ b/angular-bootstrap-checkbox.js
@@ -5,7 +5,7 @@ angular.module("ui.checkbox", []).directive("checkbox", function() {
 		scope: {},
 		require: "ngModel",
 		restrict: "E",
-		replace: "true",
+		transclude: true,
 		template: "<button type=\"button\" ng-style=\"stylebtn\" class=\"btn btn-default\" ng-class=\"{'btn-xs': size==='default', 'btn-sm': size==='large', 'btn-lg': size==='largest'}\">" +
 			"<span ng-style=\"styleicon\" class=\"glyphicon\" ng-class=\"{'glyphicon-ok': checked===true}\"></span>" +
 			"</button>",


### PR DESCRIPTION
I have a similar project and i stopped using `replace` for my directives.
Replace is a great feature but it was created in the early versions of angular js, now the angular team is advising people to not use it anymore for best practices.

You can use transclude and there is few advantages in here the linking function receives a transclusion function which is pre-bound to the correct scope. In a typical setup the widget creates an isolate scope, but the transclusion is not a child, but a sibling of the isolate scope. This makes it possible for the widget to have private state, and the transclusion to be bound to the parent (pre-isolate) scope.