### PR TITLE
Fix for mobile click registering

### DIFF
--- a/angular-bootstrap-checkbox.js
+++ b/angular-bootstrap-checkbox.js
@@ -6,7 +6,7 @@ angular.module("ui.checkbox", []).directive("checkbox", function() {
 		require: "ngModel",
 		restrict: "E",
 		replace: "true",
-		template: "<button type=\"button\" ng-style=\"stylebtn\" class=\"btn btn-default\" ng-class=\"{'btn-xs': size==='default', 'btn-sm': size==='large', 'btn-lg': size==='largest', 'checked': checked===true}\">" +
+		template: "<button ng-click=\"handleClick()\" type=\"button\" ng-style=\"stylebtn\" class=\"btn btn-default\" ng-class=\"{'btn-xs': size==='default', 'btn-sm': size==='large', 'btn-lg': size==='largest', 'checked': checked===true}\">" +
 			"<span ng-style=\"styleicon\" class=\"glyphicon\" ng-class=\"{'glyphicon-ok': checked===true}\"></span>" +
 			"</button>",
 		link: function(scope, elem, attrs, modelCtrl) {
@@ -62,15 +62,13 @@ angular.module("ui.checkbox", []).directive("checkbox", function() {
 			}, true);
 
 			// On click swap value and trigger onChange function
-			elem.bind("click", function() {
-				scope.$apply(function() {
-					if(modelCtrl.$modelValue === falseValue) {
-						modelCtrl.$setViewValue(trueValue);
-					} else {
-						modelCtrl.$setViewValue(falseValue);
-					}
-				});
-			});
+			scope.handleClick = function() {
+				if(modelCtrl.$modelValue === falseValue) {
+					modelCtrl.$setViewValue(trueValue);
+				} else {
+					modelCtrl.$setViewValue(falseValue);
+				}
+			}
 		}
 	};
 });


### PR DESCRIPTION
Instead of elem.bind use the ng-click directive on the button element in the template. This allows for mobile support for click handling without the need for any other libraries.